### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "doctrine/cache": "^1.4.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^7.0 || ^8.0",
         "symfony/phpunit-bridge": "^3.4|^4.0",
         "symfony/yaml": "^3.4|^4.0",
         "symfony/validator": "^3.4|^4.0",


### PR DESCRIPTION
## This bundle became deprecated

Please be aware that this bundle became deprecated and won't be compatible with Symfony 5 and upwards.
Read more about the deprecation and the alternatives for this bundle in the issue 
[#156](https://github.com/doctrine/DoctrineCacheBundle/issues/156).
